### PR TITLE
feat: exclude diff by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ require("retrail").setup {
     -- Excluded filetype list. Overrides `include` list.
     exclude = {
       "",
+      "diff",
       "help"
     },
   },

--- a/lua/retrail/config/defaults.lua
+++ b/lua/retrail/config/defaults.lua
@@ -18,6 +18,7 @@ return {
     -- Excluded filetype list. Overrides `include` list.
     exclude = {
       "",
+      "diff",
       "help"
     },
   },


### PR DESCRIPTION
For two reasons:
- in the diff format, an unmodified empty line contains a single space;
- the modification can concern a line containing a trailing space.