### PR TITLE
feat: exclude common plugins by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,13 @@ require("retrail").setup {
     -- Excluded filetype list. Overrides `include` list.
     exclude = {
       "",
+      "checkhealth",
       "diff",
-      "help"
+      "help",
+      "man",
+      "WhichKey",
+      "alpha",
+      "mason.nvim",
     },
   },
   -- Trim on write behaviour.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ require("retrail").setup {
     -- Excluded filetype list. Overrides `include` list.
     exclude = {
       "",
+      "alpha",
       "checkhealth",
       "diff",
       "help",
       "man",
-      "WhichKey",
-      "alpha",
       "mason.nvim",
+      "TelescopePrompt",
+      "WhichKey",
     },
   },
   -- Trim on write behaviour.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ require("retrail").setup {
       "checkhealth",
       "diff",
       "help",
+      "lspinfo",
       "man",
       "mason.nvim",
       "TelescopePrompt",

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ require("retrail").setup {
       "man",
       "mason.nvim",
       "TelescopePrompt",
+      "Trouble",
       "WhichKey",
     },
   },

--- a/lua/retrail/config/defaults.lua
+++ b/lua/retrail/config/defaults.lua
@@ -22,6 +22,7 @@ return {
       "checkhealth",
       "diff",
       "help",
+      "lspinfo",
       "man",
       "mason.nvim",
       "TelescopePrompt",

--- a/lua/retrail/config/defaults.lua
+++ b/lua/retrail/config/defaults.lua
@@ -26,6 +26,7 @@ return {
       "man",
       "mason.nvim",
       "TelescopePrompt",
+      "Trouble",
       "WhichKey",
     },
   },

--- a/lua/retrail/config/defaults.lua
+++ b/lua/retrail/config/defaults.lua
@@ -22,6 +22,9 @@ return {
       "diff",
       "help",
       "man",
+      "WhichKey",
+      "alpha",
+      "mason.nvim",
     },
   },
   -- Trim on write behaviour.

--- a/lua/retrail/config/defaults.lua
+++ b/lua/retrail/config/defaults.lua
@@ -18,13 +18,14 @@ return {
     -- Excluded filetype list. Overrides `include` list.
     exclude = {
       "",
+      "alpha",
       "checkhealth",
       "diff",
       "help",
       "man",
-      "WhichKey",
-      "alpha",
       "mason.nvim",
+      "TelescopePrompt",
+      "WhichKey",
     },
   },
   -- Trim on write behaviour.


### PR DESCRIPTION
- feat: add WhichKey, alpha and mason.nvim to exclude table
- docs: sync README.md with default config
