### PR TITLE
Exclude dashboard-nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ require("retrail").setup {
       "alpha",
       "checkhealth",
       "cmp_menu",
+      "dashboard",
       "diff",
       "lazy",
       "lspinfo",

--- a/lua/retrail/config/defaults.lua
+++ b/lua/retrail/config/defaults.lua
@@ -22,6 +22,7 @@ return {
       "alpha",
       "checkhealth",
       "cmp_menu",
+      "dashboard",
       "diff",
       "lazy",
       "lspinfo",


### PR DESCRIPTION
I was trying out LazyVim, which uses [dashboard-vim](https://github.com/nvimdev/dashboard-nvim) and reported a bunch of whitespace:

<img width="1301" alt="Screenshot 2023-11-20 at 22 44 02" src="https://github.com/kaplanz/retrail.nvim/assets/2555532/5b83d634-bf86-48e8-87d2-d49462efd4d4">

Adding this entry fixed things (in the meantime, I'm [using this](https://github.com/kaplanz/retrail.nvim/issues/6#issuecomment-1820163132) to extend the excludes locally).