### PR TITLE
Use vim window-ID to track matches

### DIFF
--- a/lua/retrail/init.lua
+++ b/lua/retrail/init.lua
@@ -104,9 +104,7 @@ function M:enabled()
 end
 
 function M.ident()
-  local win = vim.fn.tabpagenr()
-  local tab = vim.fn.winnr()
-  return string.format("%d:%d", tab, win)
+  return vim.fn.win_getid()
 end
 
 function M:matchadd()


### PR DESCRIPTION
Using window-ID ensures that matches are tracked properly across window split, swap, and loading different buffers in a window.